### PR TITLE
feat: add DarkModeToggle with lucide icons and theme handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,12 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@heroicons/react": "^2.2.0",
         "classnames": "^2.5.1",
+        "lucide-react": "^0.525.0",
         "next": "^14.1.0",
         "next-seo": "^6.4.0",
+        "next-themes": "^0.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "styled-jsx-plugin-postcss": "^4.0.1"
@@ -139,6 +142,14 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@heroicons/react": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@heroicons/react/-/react-2.2.0.tgz",
+      "integrity": "sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==",
+      "peerDependencies": {
+        "react": ">= 16 || ^19.0.0-rc"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -4083,6 +4094,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.0.30",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
@@ -4259,6 +4278,15 @@
         "next": "^8.1.1-canary.54 || >=9.0.0",
         "react": ">=16.0.0",
         "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -14,9 +14,12 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@heroicons/react": "^2.2.0",
     "classnames": "^2.5.1",
+    "lucide-react": "^0.525.0",
     "next": "^14.1.0",
     "next-seo": "^6.4.0",
+    "next-themes": "^0.4.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-jsx-plugin-postcss": "^4.0.1"

--- a/src/background/Background.tsx
+++ b/src/background/Background.tsx
@@ -2,11 +2,13 @@ import type { ReactNode } from 'react';
 
 type IBackgroundProps = {
   children: ReactNode;
-  color: string;
+  color?: string; // make it optional
 };
 
-const Background = (props: IBackgroundProps) => (
-  <div className={props.color}>{props.children}</div>
+const Background = ({ children, color = 'bg-white' }: IBackgroundProps) => (
+  <div className={`${color} transition-colors duration-300 dark:bg-gray-900`}>
+    {children}
+  </div>
 );
 
 export { Background };

--- a/src/components/theme/DarkModeToggle.tsx
+++ b/src/components/theme/DarkModeToggle.tsx
@@ -1,0 +1,28 @@
+// components/theme/DarkModeToggle.tsx
+import { Moon, Sun } from 'lucide-react'; // professional feather icons
+import { useTheme } from 'next-themes';
+import { useEffect, useState } from 'react';
+
+export default function DarkModeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) return null;
+
+  const isDark = resolvedTheme === 'dark';
+
+  return (
+    <button
+      onClick={() => setTheme(isDark ? 'light' : 'dark')}
+      aria-label="Toggle dark mode"
+      className="rounded-full border border-gray-300 bg-gray-100 p-2 
+                 text-gray-800 transition-all 
+                 duration-300 hover:scale-105 
+                 hover:shadow-md dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100"
+    >
+      {isDark ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,14 @@
 import '../styles/global.css';
 
 import type { AppProps } from 'next/app';
+import { ThemeProvider } from 'next-themes';
 
-const MyApp = ({ Component, pageProps }: AppProps) => (
-  <Component {...pageProps} />
-);
+function MyApp({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider attribute="class">
+      <Component {...pageProps} />
+    </ThemeProvider>
+  );
+}
 
 export default MyApp;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,5 +1,17 @@
+import DarkModeToggle from '../components/theme/DarkModeToggle';
 import { Base } from '../templates/Base';
 
-const Index = () => <Base />;
+const Index = () => {
+  return (
+    <div className="min-h-screen bg-white text-black transition-colors duration-300 dark:bg-black dark:text-white">
+      <div className="flex justify-end p-4">
+        <div className="rounded-full bg-gray-200 p-2 shadow-md transition duration-300 hover:scale-105 dark:bg-gray-800">
+          <DarkModeToggle />
+        </div>
+      </div>
+      <Base />
+    </div>
+  );
+};
 
 export default Index;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  darkMode: 'class', // <-- ✅ ADD THIS LINE
   content: ['./src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     fontSize: {


### PR DESCRIPTION
### Summary

- Created `DarkModeToggle` in `components/theme/DarkModeToggle.tsx`.
- Added and configured the `next-themes` package to manage theme switching (`light`/`dark`).
- Used `lucide-react` icons (`Sun`, `Moon`) for a modern toggle button.
- Handles SSR hydration by waiting for the component to mount.
- Fully styled with Tailwind CSS using `dark:` variants for theme-based appearance.

### How it works

- On button click, toggles between `light` and `dark` mode using `setTheme()`.
- Uses `resolvedTheme` to determine current theme.
- Button styling and icon updates based on the active theme.

### Note

Dark mode toggle is functional ✅  
However, some components use hardcoded colors like `text-black` or `bg-white`, causing poor contrast in dark mode.

---

🔧 Tracked in a separate issue: #4 >